### PR TITLE
mem: Add a readString method to the PortProxy which takes a char *.

### DIFF
--- a/src/mem/port_proxy.cc
+++ b/src/mem/port_proxy.cc
@@ -110,3 +110,18 @@ PortProxy::tryReadString(std::string &str, Addr addr) const
         str += c;
     }
 }
+
+bool
+PortProxy::tryReadString(char *str, Addr addr, size_t maxlen) const
+{
+    while (maxlen--) {
+        if (!tryReadBlob(addr++, str, 1)) {
+            return false;
+        }
+      if (!*++str)
+        return true;
+    }
+    // We ran out of room, so back up and add a terminator.
+    *--str = '\0';
+    return true;
+}

--- a/src/mem/port_proxy.hh
+++ b/src/mem/port_proxy.hh
@@ -59,6 +59,8 @@
 #ifndef __MEM_PORT_PROXY_HH__
 #define __MEM_PORT_PROXY_HH__
 
+#include <limits>
+
 #include "mem/port.hh"
 #include "sim/byteswap.hh"
 
@@ -240,6 +242,23 @@ class PortProxy
     readString(std::string &str, Addr addr) const
     {
         if (!tryReadString(str, addr))
+            fatal("readString(%#x, ...) failed", addr);
+    }
+
+    /**
+     * Reads the string at guest address addr into the char * str, reading up
+     * to maxlen characters. The last character read is always a nul
+     * terminator. Returns true on success and false on failure.
+     */
+    bool tryReadString(char *str, Addr addr, size_t maxlen) const;
+
+    /**
+     * Same as tryReadString, but insists on success.
+     */
+    void
+    readString(char *str, Addr addr, size_t maxlen) const
+    {
+        if (!tryReadString(str, addr, maxlen))
             fatal("readString(%#x, ...) failed", addr);
     }
 };


### PR DESCRIPTION
This version takes a char * instead of an std::string &, and a maximum
length to fill in like strncpy. This is intended to be a replacement
for the CopyStringOut function.